### PR TITLE
QnA 4단계 구현

### DIFF
--- a/src/main/java/nextstep/domain/Answer.java
+++ b/src/main/java/nextstep/domain/Answer.java
@@ -7,6 +7,7 @@ import support.domain.UrlGeneratable;
 
 import javax.persistence.*;
 import javax.validation.constraints.Size;
+import java.time.LocalDateTime;
 
 @Entity
 public class Answer extends AbstractEntity implements UrlGeneratable {
@@ -70,7 +71,7 @@ public class Answer extends AbstractEntity implements UrlGeneratable {
         return deleted;
     }
 
-    public void delete(final User loginUser) {
+    public DeleteHistory delete(final User loginUser) {
 
         if (isDeleted()) {
             throw new CannotDeleteException("Deleted answer.");
@@ -81,6 +82,12 @@ public class Answer extends AbstractEntity implements UrlGeneratable {
         }
 
         this.deleted = true;
+
+        return createDeleteHistory(loginUser);
+    }
+
+    private DeleteHistory createDeleteHistory(final User loginUser) {
+        return new DeleteHistory(ContentType.ANSWER, this.getId(), loginUser, LocalDateTime.now());
     }
 
     public void update(final User loginUser, final Answer answer) {

--- a/src/main/java/nextstep/domain/Answers.java
+++ b/src/main/java/nextstep/domain/Answers.java
@@ -1,0 +1,44 @@
+package nextstep.domain;
+
+import org.hibernate.annotations.Where;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Embeddable;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderBy;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+@Embeddable
+public class Answers {
+
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL)
+    @Where(clause = "deleted = false")
+    @OrderBy("id ASC")
+    private List<Answer> answers = new ArrayList<>();
+
+    public List<Answer> getAnswers() {
+        return answers.stream().filter(answer -> !answer.isDeleted()).collect(toList());
+    }
+
+    public void addAnswer(final Answer answer, final Question question) {
+        answer.toQuestion(question);
+        answers.add(answer);
+    }
+
+    public List<DeleteHistory> deleteAll(final User loginUser) {
+        List<DeleteHistory> deleteHistories = new ArrayList<>();
+        for (Answer answer : getAnswers()) {
+            deleteHistories.add(answer.delete(loginUser));
+        }
+        return deleteHistories;
+    }
+
+    public boolean hasAnswers() {
+        final List<Answer> answers = getAnswers();
+        return !answers.isEmpty();
+    }
+
+}

--- a/src/main/java/nextstep/service/QnaService.java
+++ b/src/main/java/nextstep/service/QnaService.java
@@ -60,10 +60,11 @@ public class QnaService {
     }
 
     @Transactional
-    public void delete(final User loginUser, final long id) throws CannotDeleteException {
+    public List<DeleteHistory> delete(final User loginUser, final long id) throws CannotDeleteException {
         final Question question = findById(id);
         final List<DeleteHistory> deleteHistories = question.delete(loginUser);
         deleteHistoryService.saveAll(deleteHistories);
+        return deleteHistories;
     }
 
     @Transactional

--- a/src/main/java/nextstep/service/QnaService.java
+++ b/src/main/java/nextstep/service/QnaService.java
@@ -61,7 +61,9 @@ public class QnaService {
 
     @Transactional
     public void delete(final User loginUser, final long id) throws CannotDeleteException {
-        findById(id).delete(loginUser);
+        final Question question = findById(id);
+        final List<DeleteHistory> deleteHistories = question.delete(loginUser);
+        deleteHistoryService.saveAll(deleteHistories);
     }
 
     @Transactional

--- a/src/test/java/nextstep/domain/AnswerTest.java
+++ b/src/test/java/nextstep/domain/AnswerTest.java
@@ -84,6 +84,20 @@ public class AnswerTest {
         answer.delete(createUser("javajigi", "test", "자바지기", "javajigi@slipp.net"));
     }
 
+    @Test(expected = CannotDeleteException.class)
+    public void 질문한_사람과_로그인한_사람이_같지만_답변의_글쓴이가_다른_경우_삭제_가능하지_않음() {
+
+        final User loginUser = createUser("ninezero90hy", "ninezero90hy@", "ninezero", "ninezero90hy@gmail.com");
+
+        final Question question = newQuestion("타이틀", "내용");
+        final User newUser = createUser("javajigi", "test", "자바지기", "javajigi@slipp.net");
+        final Answer answer = new Answer(newUser, "좋은 책이네요.");
+        question.writeBy(createUser("ninezero90hy", "ninezero90hy@", "ninezero", "ninezero90hy@gmail.com"));
+        question.addAnswer(answer);
+
+        answer.delete(loginUser);
+    }
+
     private User createUser(final String userId, final String password, final String name, final String email) {
         return new User(userId, password, name, email);
     }

--- a/src/test/java/nextstep/domain/QuestionTest.java
+++ b/src/test/java/nextstep/domain/QuestionTest.java
@@ -122,16 +122,10 @@ public class QuestionTest {
         final User write = createUser("ninezero90hy", "ninezero90hy@", "ninezero", "ninezero90hy@gmail.com");
         question.writeBy(write);
         question.addAnswer(new Answer(write, "좋은 책이네요.~"));
-        question.addAnswer(new Answer(write, "좋은 책이네요.!"));
-        question.addAnswer(new Answer(write, "좋은 책이네요.#"));
-        question.addAnswer(new Answer(write, "좋은 책이네요.$"));
-        question.addAnswer(new Answer(write, "좋은 책이네요.%"));
-        question.addAnswer(new Answer(write, "좋은 책이네요.^"));
-        question.addAnswer(new Answer(write, "좋은 책이네요.*"));
         assertThat(question.hasAnswers()).isTrue();
 
         final List<DeleteHistory> deleteHistories = question.delete(loginUser);
-        assertThat(deleteHistories.size()).isEqualTo(8);
+        assertThat(deleteHistories.size()).isEqualTo(2);
         assertThat(question.hasAnswers()).isFalse();
     }
 

--- a/src/test/java/nextstep/service/QnaServiceTest.java
+++ b/src/test/java/nextstep/service/QnaServiceTest.java
@@ -107,30 +107,30 @@ public class QnaServiceTest extends BaseTest {
         assertThat(question1.getContents()).isEqualTo(question2.getContents());
     }
 
-    @Test
-    public void 질문_삭제_성공() throws CannotDeleteException {
-
-        final User user = createUser("javajigi", "test", "자바지기", "javajigi@slipp.net");
-        final Question question = createUserAndQuestion(user, "국내에서 Ruby on Rails와 Play가 활성화되기 힘든 이유는 뭘까?", "Ruby on Rails(이하 RoR)는 2006년 즈음에 정말 뜨겁게 달아올랐다가 금방 가라 앉았다.");
-
-        when(questionRepository.findById(question.getId())).thenReturn(Optional.of(question));
-
-        qnaService.delete(user, 1);
-
-        assertThat(question.isDeleted()).isTrue();
-    }
-
-    @Test(expected = CannotDeleteException.class)
-    public void 삭제된_질문_다시_삭제_시도() throws CannotDeleteException {
-
-        final User user = createUser("javajigi", "test", "자바지기", "javajigi@slipp.net");
-        final Question question = createUserAndQuestion(user, "국내에서 Ruby on Rails와 Play가 활성화되기 힘든 이유는 뭘까?", "Ruby on Rails(이하 RoR)는 2006년 즈음에 정말 뜨겁게 달아올랐다가 금방 가라 앉았다.");
-
-        when(questionRepository.findById(question.getId())).thenReturn(Optional.of(question));
-
-        qnaService.delete(user, 1);
-        qnaService.delete(user, 1);
-    }
+//    @Test
+//    public void 질문_삭제_성공() throws CannotDeleteException {
+//
+//        final User user = createUser("javajigi", "test", "자바지기", "javajigi@slipp.net");
+//        final Question question = createUserAndQuestion(user, "국내에서 Ruby on Rails와 Play가 활성화되기 힘든 이유는 뭘까?", "Ruby on Rails(이하 RoR)는 2006년 즈음에 정말 뜨겁게 달아올랐다가 금방 가라 앉았다.");
+//
+//        when(questionRepository.findById(question.getId())).thenReturn(Optional.of(question));
+//
+//        qnaService.delete(user, 1);
+//
+//        assertThat(question.isDeleted()).isTrue();
+//    }
+//
+//    @Test(expected = CannotDeleteException.class)
+//    public void 삭제된_질문_다시_삭제_시도() throws CannotDeleteException {
+//
+//        final User user = createUser("javajigi", "test", "자바지기", "javajigi@slipp.net");
+//        final Question question = createUserAndQuestion(user, "국내에서 Ruby on Rails와 Play가 활성화되기 힘든 이유는 뭘까?", "Ruby on Rails(이하 RoR)는 2006년 즈음에 정말 뜨겁게 달아올랐다가 금방 가라 앉았다.");
+//
+//        when(questionRepository.findById(question.getId())).thenReturn(Optional.of(question));
+//
+//        qnaService.delete(user, 1);
+//        qnaService.delete(user, 1);
+//    }
 
     @Test(expected = CannotDeleteException.class)
     public void 작성자가_아닌데_질문_삭제_시도() throws CannotDeleteException {

--- a/src/test/java/nextstep/service/QnaServiceTest.java
+++ b/src/test/java/nextstep/service/QnaServiceTest.java
@@ -131,6 +131,18 @@ public class QnaServiceTest extends BaseTest {
     }
 
     @Test(expected = CannotDeleteException.class)
+    public void 삭제된_질문_다시_삭제_시도() throws CannotDeleteException {
+
+        final User user = createUser("javajigi", "test", "자바지기", "javajigi@slipp.net");
+        final Question question = createUserAndQuestion(user, "국내에서 Ruby on Rails와 Play가 활성화되기 힘든 이유는 뭘까?", "Ruby on Rails(이하 RoR)는 2006년 즈음에 정말 뜨겁게 달아올랐다가 금방 가라 앉았다.");
+
+        when(questionRepository.findById(question.getId())).thenReturn(Optional.of(question));
+
+        qnaService.delete(user, 1);
+        qnaService.delete(user, 1);
+    }
+
+    @Test(expected = CannotDeleteException.class)
     public void 작성자가_아닌데_질문_삭제_시도() throws CannotDeleteException {
 
         final User write = createUser("javajigi", "test", "자바지기", "javajigi@slipp.net");

--- a/src/test/java/nextstep/service/QnaServiceTest.java
+++ b/src/test/java/nextstep/service/QnaServiceTest.java
@@ -11,6 +11,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import support.test.BaseTest;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -26,8 +27,15 @@ public class QnaServiceTest extends BaseTest {
     @Mock
     private AnswerRepository answerRepository;
 
+    @Mock
+    private DeleteHistoryRepository deleteHistoryRepository;
+
     @InjectMocks
     private QnaService qnaService;
+
+    @SuppressWarnings("unused")
+    @Mock
+    private DeleteHistoryService deleteHistoryService;
 
     @Test
     public void 질문_등록() {
@@ -107,30 +115,20 @@ public class QnaServiceTest extends BaseTest {
         assertThat(question1.getContents()).isEqualTo(question2.getContents());
     }
 
-//    @Test
-//    public void 질문_삭제_성공() throws CannotDeleteException {
-//
-//        final User user = createUser("javajigi", "test", "자바지기", "javajigi@slipp.net");
-//        final Question question = createUserAndQuestion(user, "국내에서 Ruby on Rails와 Play가 활성화되기 힘든 이유는 뭘까?", "Ruby on Rails(이하 RoR)는 2006년 즈음에 정말 뜨겁게 달아올랐다가 금방 가라 앉았다.");
-//
-//        when(questionRepository.findById(question.getId())).thenReturn(Optional.of(question));
-//
-//        qnaService.delete(user, 1);
-//
-//        assertThat(question.isDeleted()).isTrue();
-//    }
-//
-//    @Test(expected = CannotDeleteException.class)
-//    public void 삭제된_질문_다시_삭제_시도() throws CannotDeleteException {
-//
-//        final User user = createUser("javajigi", "test", "자바지기", "javajigi@slipp.net");
-//        final Question question = createUserAndQuestion(user, "국내에서 Ruby on Rails와 Play가 활성화되기 힘든 이유는 뭘까?", "Ruby on Rails(이하 RoR)는 2006년 즈음에 정말 뜨겁게 달아올랐다가 금방 가라 앉았다.");
-//
-//        when(questionRepository.findById(question.getId())).thenReturn(Optional.of(question));
-//
-//        qnaService.delete(user, 1);
-//        qnaService.delete(user, 1);
-//    }
+    @Test
+    public void 질문_삭제_성공() throws CannotDeleteException {
+
+        final User user = createUser("javajigi", "test", "자바지기", "javajigi@slipp.net");
+        final Question question = createUserAndQuestion(user, "국내에서 Ruby on Rails와 Play가 활성화되기 힘든 이유는 뭘까?", "Ruby on Rails(이하 RoR)는 2006년 즈음에 정말 뜨겁게 달아올랐다가 금방 가라 앉았다.");
+
+        when(questionRepository.findById(question.getId())).thenReturn(Optional.of(question));
+
+        final List<DeleteHistory> deleteHistories = qnaService.delete(user, 1);
+        when(deleteHistoryRepository.findAll()).thenReturn(deleteHistories);
+
+        assertThat(question.isDeleted()).isTrue();
+        assertThat(deleteHistoryRepository.findAll()).isEqualTo(deleteHistories);
+    }
 
     @Test(expected = CannotDeleteException.class)
     public void 작성자가_아닌데_질문_삭제_시도() throws CannotDeleteException {


### PR DESCRIPTION
@javajigi 강사님 많이 생각해 봤는데 해결할 수 있는 방법을 몰라서 질문 드립니다.

- QnaServiceTest
`질문_삭제_성공` 하는 테스트 케이스가 있는데요.

```java
@Transactional
public void delete(final User loginUser, final long id) throws CannotDeleteException {
  final Question question = findById(id);
  final List<DeleteHistory> deleteHistories = question.delete(loginUser);
  deleteHistoryService.saveAll(deleteHistories);
}
```

실제 QnA 서비스에서 삭제 처리할 떄 히스토리를 디비에 저장하는 로직 떄문에 해당 테스트가 실패합니다.

Question 도메인 테스트에서 `질문한_사람과_로그인한_사람이_같으면서_답변의_작성자가_같은_경우_삭제_가능하고_삭제한_이력정보가_남아야한다` 삭제 히스토리가 정상적으로 생성 되었는지 테스트하는 것으로 만족해야하는 것인가요?

Question 서비스의 삭제 로직을 테스트 할 수 있는 방법이 있을까요?